### PR TITLE
Add support for NLI1 section (ID labels)

### DIFF
--- a/LMS.cs
+++ b/LMS.cs
@@ -140,6 +140,19 @@ namespace CLMS
 
             return labels;
         }
+        public static Dictionary<uint, uint> getNumLines(BinaryDataReader bdr)
+        {
+            uint numOfLines = bdr.ReadUInt32();
+
+            Dictionary<uint, uint> lines = new Dictionary<uint, uint>();
+            for (uint i = 0; i < numOfLines; i++)
+            {
+                uint id = bdr.ReadUInt32();
+                uint index = bdr.ReadUInt32();
+                lines.Add(id, index);
+            }
+            return lines;
+        }
         public static Attribute[] getAttributes(BinaryDataReader bdr, long cSectionSize)
         {
             long startPosition = bdr.Position;

--- a/MSBT.cs
+++ b/MSBT.cs
@@ -310,8 +310,11 @@ namespace CLMS
 
             bdr.ByteOrder = header.byteOrder;
 
-            for (int i = 0; (i < header.numberOfSections || bdr.EndOfStream) || (i < header.numberOfSections && bdr.EndOfStream); i++)
+            for (int i = 0; (i < header.numberOfSections) || (i < header.numberOfSections); i++)
             {
+                if (bdr.EndOfStream)
+                    continue;
+
                 string cSectionMagic = bdr.ReadASCIIString(4);
                 uint cSectionSize = bdr.ReadUInt32();
                 bdr.skipBytes(8);


### PR DESCRIPTION
Supports the NLI1 section which contain a table of 2 uints (ID and message index). This also makes labels not required for saving. 

Saving has been tested and works correctly for these. 