### PR TITLE
MSBT Additions and improvements

### DIFF
--- a/CLMS.sln
+++ b/CLMS.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CLMS", "CLMS.csproj", "{8D31697E-8D77-4A28-AB06-B309D3694FAA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSBPTool", "..\MSBPTool\MSBPTool.csproj", "{AA710BA6-C898-4316-8C61-EA4B556FAB09}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{8D31697E-8D77-4A28-AB06-B309D3694FAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8D31697E-8D77-4A28-AB06-B309D3694FAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8D31697E-8D77-4A28-AB06-B309D3694FAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA710BA6-C898-4316-8C61-EA4B556FAB09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA710BA6-C898-4316-8C61-EA4B556FAB09}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA710BA6-C898-4316-8C61-EA4B556FAB09}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA710BA6-C898-4316-8C61-EA4B556FAB09}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Formats/MSBP.cs
+++ b/Formats/MSBP.cs
@@ -470,6 +470,8 @@ namespace CLMS
 
         public bool ContainsControlTag(TagConfig aTagConfig)
         {
+            if (ControlTags == null) return false;
+
             foreach (var cControlTagGroup in ControlTags)
             {
                 for (ushort j = 0; j < cControlTagGroup.Value.ControlTagTypes.Count; j++)
@@ -638,7 +640,7 @@ namespace CLMS
                 {
                     Colors.Type = LMSDictionaryKeyType.None;
 
-                    for (uint i = 0; i < clb1.LabelHolder.Labels.Length; i++)
+                    for (uint i = 0; i < clb1.LabelHolder?.Labels?.Length; i++)
                     {
                         Colors.Add(clr1.Colors[i]);
                     }

--- a/Formats/MSBP.cs
+++ b/Formats/MSBP.cs
@@ -430,18 +430,15 @@ namespace CLMS
         #region TagControl getting
         public TagConfig TryGetTagConfigByControlTag(string aTagGroup, string aTagType)
         {
-            for (ushort group = 0; group < ControlTags.Count; group++)
+            foreach (var tagGroup in ControlTags)
             {
-                if (ControlTags[group].Name == aTagGroup)
+                if (tagGroup.Value.Name == aTagGroup)
                 {
-                    for (ushort type = 0; type < ControlTags[group].ControlTagTypes.Count; type++)
-                    {
-                        if (ControlTags[group].ControlTagTypes[type].Name == aTagType)
-                        {
-                            return new(group, type);
-                        }
+                    for (ushort type = 0; type < tagGroup.Value.ControlTagTypes.Count; type++) {
+                        if (tagGroup.Value.ControlTagTypes[type].Name == aTagType)
+                            return new(tagGroup.Key, type);
                     }
-                }
+                } 
             }
             throw new Exception("TagGroup does not exist: " + aTagGroup);
         }

--- a/Formats/MSBP.cs
+++ b/Formats/MSBP.cs
@@ -872,14 +872,27 @@ namespace CLMS
             (string, ushort, ushort[])[] tagGroupData = new (string, ushort, ushort[])[tagGroupNum];
             reader.SkipBytes(2);
 
+            ushort idx = 0;
             for (uint i = 0; i < tagGroupNum; i++)
             {
                 uint cTagGroupPosition = reader.ReadUInt32();
                 long positionBuf = reader.Position;
                 reader.Position = startPosition + cTagGroupPosition;
 
-                ushort cTagGroupIndex = reader.ReadUInt16();
-                ushort numOfTagIndices = reader.ReadUInt16();
+                ushort cTagGroupIndex;
+                ushort numOfTagIndices;
+                if (this.VersionNumber <= 3) //no index, just counter
+                {
+                    numOfTagIndices = reader.ReadUInt16();
+                    cTagGroupIndex = idx;
+                    idx += numOfTagIndices; //calculate index
+                }
+                else
+                {
+                    cTagGroupIndex = reader.ReadUInt16();
+                    numOfTagIndices = reader.ReadUInt16();
+                }
+
                 ushort[] cTagGroupTypeIndices = new ushort[numOfTagIndices];
 
                 for (uint j = 0; j < numOfTagIndices; j++)
@@ -1235,7 +1248,8 @@ namespace CLMS
                 long cMessageOffset = writer.Position;
                 writer.GoBackWriteRestore(hashTablePosBuf + (i * 4), (uint)(cMessageOffset - startPosition));
 
-                writer.Write(tagGroupData[i].Index);
+                if (this.VersionNumber > 3)
+                   writer.Write(tagGroupData[i].Index);
                 writer.Write((ushort)tagGroupData[i].TagIndices.Length);
 
                 for (uint j = 0; j < tagGroupData[i].TagIndices.Length; j++)

--- a/Formats/MSBT.cs
+++ b/Formats/MSBT.cs
@@ -200,7 +200,7 @@ namespace CLMS
                     {
                         messageNode.Add("AttributeString", item.Value.Attribute.String);
                     }
-                    if (item.Value.Attribute.Data.Length > 0)
+                    if (item.Value.Attribute != null && item.Value.Attribute.Data.Length > 0)
                     {
                        if (message_project != null)
                         {
@@ -239,7 +239,7 @@ namespace CLMS
 
                 if (HasStyleIndices)
                 {
-                    if (message_project != null)
+                    if (item.Value.StyleIndex != -1 && message_project != null && message_project.Styles.Keys.Count > item.Value.StyleIndex)
                     {
                         var style = message_project.Styles.Keys.ToList()[item.Value.StyleIndex];
                         messageNode.Add($"MSBP_Style", style.ToString());
@@ -954,11 +954,13 @@ namespace CLMS
                 Message cMessage = new();
                 if (isTSY1)
                 {
-                    cMessage.StyleIndex = sty1.StyleIndices[i];
+                    if (sty1.StyleIndices.Length > i)
+                        cMessage.StyleIndex = sty1.StyleIndices[i];
                 }
                 if (isATR1)
                 {
-                    cMessage.Attribute = atr1.Attributes[i];
+                    if (atr1.Attributes.Length > i)
+                        cMessage.Attribute = atr1.Attributes[i];
                 }
                 uint cStringOffset = reader.ReadUInt32();
                 long positionBuf = reader.Position;


### PR DESCRIPTION
Adds
- YAML conversion has MSBP argument for visualizing tag, style, and attribute info. These use the MSBP_ yaml nodes. If one is not providied, it uses the same yaml conversion code that is currently being used,
- XML conversion. Has no MSBP visuals yet. Can be a bit more readable than yaml and xml end tags can help visualize spaces at the end of messages.

Fixes
- Loading/saving MSBP <= version 3. 

